### PR TITLE
docs: expand engine crates rustdoc

### DIFF
--- a/lib/engine/engine-core/src/automata/mod.rs
+++ b/lib/engine/engine-core/src/automata/mod.rs
@@ -52,17 +52,28 @@ pub struct GpuGridSlice {
 /// [`AutomataRegistry`].  It’s *not* a component because UI code needs
 /// to access it even when the automaton entity might not be in scope.
 pub struct AutomatonInfo {
-    pub id:               AutomatonId,
-    pub name:             String,
-    pub rule:             Arc<dyn AutomatonRule<D = Dim> + Send + Sync>,
-    pub params:           Value,
-    pub seed_fn:          Option<fn(&mut ())>, // placeholder until CPU grid returns
-    pub slice:            GpuGridSlice,
-    pub dimension:        u8,                  // kept for backwards-compat with old UI
-    pub voxel_size:       f32,
-    pub world_offset:     Vec3,
+    /// Logical identifier assigned by the CPU registry.
+    pub id: AutomatonId,
+    /// Human‑readable name of the automaton/rule.
+    pub name: String,
+    /// Rule implementation driving the simulation.
+    pub rule: Arc<dyn AutomatonRule<D = Dim> + Send + Sync>,
+    /// Arbitrary JSON parameters passed to the rule.
+    pub params: Value,
+    /// Optional CPU seeding function.
+    pub seed_fn: Option<fn(&mut ())>, // placeholder until CPU grid returns
+    /// Slice inside the global GPU atlas where state is stored.
+    pub slice: GpuGridSlice,
+    /// Dimensionality of the automaton.
+    pub dimension: u8, // kept for backwards-compat with old UI
+    /// Size of one voxel edge in world units.
+    pub voxel_size: f32,
+    /// Translation applied to position the automaton in world space.
+    pub world_offset: Vec3,
+    /// Clear colour used for empty space.
     pub background_color: Color,
-    pub palette:          Option<Vec<Color>>,
+    /// Optional colour palette for visualisation.
+    pub palette: Option<Vec<Color>>,
 }
 
 impl std::fmt::Debug for AutomatonInfo {

--- a/lib/engine/engine-core/src/events.rs
+++ b/lib/engine/engine-core/src/events.rs
@@ -44,8 +44,8 @@ pub enum AutomataCommand {
 ///              Bevy ECS (GPU slice allocator needs this)
 #[derive(Event)]
 pub struct AutomatonAdded {
-    pub id:     AutomatonId,    // logical CPU‑side handle
-    pub entity: Entity,         // ECS entity for GPU slice allocation
+    pub id: AutomatonId, // logical CPU‑side handle
+    pub entity: Entity,  // ECS entity for GPU slice allocation
 }
 
 /// Emitted when an automaton is removed (optional convenience).
@@ -54,9 +54,10 @@ pub struct AutomatonRemoved {
     pub id: AutomatonId,
 }
 
-
-#[derive(Event, Debug, Clone, Copy)]  
+#[derive(Event, Debug, Clone, Copy)]
+/// Toggles the visibility of the debug grid overlay.
 pub struct ToggleDebugGrid;
 
 #[derive(Event, Debug, Clone, Copy)]
+/// Requests that a flat debug floor be spawned.
 pub struct GenerateDebugFloor;

--- a/lib/engine/engine-core/src/lib.rs
+++ b/lib/engine/engine-core/src/lib.rs
@@ -1,3 +1,11 @@
+//! Core ECS resources and runtime logic shared across the engine.
+//!
+//! This crate hosts low-level building blocks used by rendering, GPU compute
+//! and higher level gameplay systems.  Everything exposed here is intended to
+//! be stable for consumers within the workspace.
+
+#![warn(missing_docs)]
+
 pub mod prelude;
 
 pub mod automata;
@@ -6,4 +14,3 @@ pub mod world;
 
 pub mod events;
 pub mod plugin;
-

--- a/lib/engine/engine-core/src/prelude.rs
+++ b/lib/engine/engine-core/src/prelude.rs
@@ -1,9 +1,10 @@
+//! Convenience re-exports for engine-core consumers.
+
 pub use crate::{
-    events::*,
     automata::AutomatonInfo,
+    events::*,
     systems::{registry::*, schedule::*, state::AppState},
     world::*,
-    
 };
 
 pub use bevy::prelude::*;

--- a/lib/engine/engine-core/src/systems/mod.rs
+++ b/lib/engine/engine-core/src/systems/mod.rs
@@ -1,3 +1,5 @@
+//! Scheduling utilities and long-lived application systems.
+
 pub mod registry;
 pub mod schedule;
 pub mod state;

--- a/lib/engine/engine-core/src/systems/schedule/mod.rs
+++ b/lib/engine/engine-core/src/systems/schedule/mod.rs
@@ -8,9 +8,13 @@
 //! the sets and Bevy guarantees correct sequencing.
 use bevy::prelude::*;
 
+/// Canonical ordering for engine systems within Bevy's `Update` schedule.
 #[derive(SystemSet, Debug, Hash, PartialEq, Eq, Clone, Copy)]
 pub enum MainSet {
+    /// User input and external events.
     Input,
+    /// Deterministic simulation and game logic.
     Logic,
+    /// Rendering and UI work.
     Render,
 }

--- a/lib/engine/engine-core/src/systems/simulation/mod.rs
+++ b/lib/engine/engine-core/src/systems/simulation/mod.rs
@@ -25,10 +25,7 @@
 //! ```
 use std::time::Duration;
 
-use bevy::{
-    prelude::*,
-    time::Fixed,
-};
+use bevy::{prelude::*, time::Fixed};
 
 /* ===================================================================== */
 /* Resources                                                             */
@@ -48,7 +45,10 @@ impl FixedStepConfig {
     #[inline]
     pub fn from_hz(hz: u32, max_steps_per_frame: u8) -> Self {
         let dt = Duration::from_secs_f64(1.0 / hz as f64);
-        Self { dt, max_steps_per_frame }
+        Self {
+            dt,
+            max_steps_per_frame,
+        }
     }
 }
 
@@ -56,7 +56,8 @@ impl FixedStepConfig {
 /// can interpolate: `alpha = accum / dt` (see `RenderInterpolator`).
 #[derive(Resource, Default, Debug)]
 pub struct SimAccumulator {
-    pub accum: f64,   // seconds
+    /// Real time accumulated since the last simulation tick, in seconds.
+    pub accum: f64,
 }
 
 /* ===================================================================== */
@@ -83,9 +84,9 @@ pub struct SimulationStep;
 #[allow(clippy::needless_pass_by_value)]
 pub fn accumulate_and_step(
     time_fixed: Res<Time<Fixed>>,
-    cfg:        Res<FixedStepConfig>,
-    mut acc:    ResMut<SimAccumulator>,
-    mut steps:  EventWriter<SimulationStep>,
+    cfg: Res<FixedStepConfig>,
+    mut acc: ResMut<SimAccumulator>,
+    mut steps: EventWriter<SimulationStep>,
 ) {
     // Pull the *exact* fixed-timestep delta (e.g. 1/60 s == 16 666 µs).
     acc.accum += time_fixed.delta_secs() as f64;
@@ -96,7 +97,7 @@ pub fn accumulate_and_step(
     while acc.accum >= dt_sec && cnt < cfg.max_steps_per_frame {
         steps.write(SimulationStep);
         acc.accum -= dt_sec;
-        cnt       += 1;
+        cnt += 1;
     }
 
     // Clamp runaway accumulators to avoid spiral-of-death.

--- a/lib/engine/engine-core/src/systems/state/resources.rs
+++ b/lib/engine/engine-core/src/systems/state/resources.rs
@@ -22,7 +22,7 @@ pub struct RuntimeFlags {
 
 impl FromWorld for RuntimeFlags {
     fn from_world(world: &mut World) -> Self {
-        let settings      = world.get_resource::<Settings>();
+        let settings = world.get_resource::<Settings>();
         let force_cpu_env = std::env::var_os("SOUL_CPU").is_some();
         Self {
             gpu_enabled: settings.map_or(true, |s| s.gpu_compute) && !force_cpu_env,
@@ -30,14 +30,14 @@ impl FromWorld for RuntimeFlags {
     }
 }
 
-
 /// Runtime counters.
 #[derive(Resource, Debug, Default)]
 pub struct Session {
-    pub frame:      u64,
+    /// Number of frames rendered since start.
+    pub frame: u64,
+    /// Whether the simulation is currently paused.
     pub sim_paused: bool,
 }
-
 
 /// User / application preferences (saved as TOML).
 #[derive(Resource, Debug, Clone, Serialize, Deserialize)]
@@ -45,7 +45,7 @@ pub struct Settings {
     /// Master volume (0–1).  *Not used yet.*
     pub master_volume: f32,
     /// Base egui font size.
-    pub ui_font_size:  f32,
+    pub ui_font_size: f32,
 
     /// Autosave enabled?
     pub autosave: bool,
@@ -58,7 +58,13 @@ pub struct Settings {
 
 impl Default for Settings {
     fn default() -> Self {
-        Self { master_volume: 1.0, ui_font_size: 16.0, autosave: true, autosave_interval: 30, gpu_compute: true, }
+        Self {
+            master_volume: 1.0,
+            ui_font_size: 16.0,
+            autosave: true,
+            autosave_interval: 30,
+            gpu_compute: true,
+        }
     }
 }
 
@@ -74,6 +80,7 @@ impl Settings {
             .unwrap_or_default()
     }
 
+    /// Persist the settings to disk.
     pub fn save(&self) {
         let _ = fs::create_dir_all(Self::config_dir());
         let path = Settings::config_path();
@@ -83,7 +90,9 @@ impl Settings {
     }
 
     fn config_dir() -> PathBuf {
-        dirs_next::document_dir().unwrap_or(PathBuf::from(".")).join("SOUL")
+        dirs_next::document_dir()
+            .unwrap_or(PathBuf::from("."))
+            .join("SOUL")
     }
 
     fn config_path() -> PathBuf {

--- a/lib/engine/engine-core/src/world/voxel_world.rs
+++ b/lib/engine/engine-core/src/world/voxel_world.rs
@@ -3,14 +3,21 @@
 use bevy::prelude::*;
 use glam::IVec3;
 use simulation_kernel::{
-    core::{cell::CellState, dim::{Dim, Dimensionality}},
+    core::{
+        cell::CellState,
+        dim::{Dim, Dimensionality},
+    },
     grid::GridBackend,
 };
 
+/// Bevy resource that owns a 3‑D voxel grid (dense **or** sparse).
 #[derive(Resource)]
 pub struct VoxelWorld {
-    pub backend:   GridBackend,   // Dense | Sparse
-    pub voxel_size: f32,          // world-units per voxel edge
+    /// Dense or sparse grid backend storing cell state.
+    pub backend: GridBackend,
+    /// World‑space size of one voxel edge.
+    pub voxel_size: f32,
+    /// Background colour used when rendering empty cells.
     pub bg_color: Color,
 }
 
@@ -22,7 +29,7 @@ impl VoxelWorld {
         for (i, off) in Dim::NEIGHBOUR_OFFSETS.iter().enumerate() {
             let p = coord + *off;
             n[i] = match &self.backend {
-                GridBackend::Dense(g)  => g.get(p).map_or(CellState::Dead, |c| c.state),
+                GridBackend::Dense(g) => g.get(p).map_or(CellState::Dead, |c| c.state),
                 GridBackend::Sparse(g) => g.get(p).map_or(CellState::Dead, |c| c.state),
             };
         }

--- a/lib/engine/engine-gpu/src/lib.rs
+++ b/lib/engine/engine-gpu/src/lib.rs
@@ -4,16 +4,18 @@
 //! the surface re-exports from this file – everything else is private
 //! implementation detail.
 
+#![warn(missing_docs)]
+
 pub use plugin::GpuAutomataComputePlugin;
 pub use types::AutomatonParams;
 
 /* internal */
-mod types;
-mod pipelines;
-mod graph;
-mod plugin;
 mod compute;
+mod graph;
+mod pipelines;
+mod plugin;
 mod seed;
+mod types;
 
 #[cfg(feature = "mesh_shaders")]
 pub mod ash;

--- a/lib/engine/engine-gpu/src/pipelines.rs
+++ b/lib/engine/engine-gpu/src/pipelines.rs
@@ -9,12 +9,15 @@ use std::borrow::Cow;
 use bevy::prelude::*;
 use bevy::render::{render_resource::*, renderer::RenderDevice};
 
+/// Simple wrapper storing cached compute pipelines keyed by rule ID.
 #[derive(Resource, Default, Clone)]
 pub struct GpuPipelineCache {
+    /// Mapping from rule identifier to compiled pipeline ID.
     pub map: std::collections::HashMap<String, CachedComputePipelineId>,
 }
 
 impl GpuPipelineCache {
+    /// Retrieve an existing pipeline or compile a new one from WGSL source.
     pub fn get_or_create(
         &mut self,
         id: &str,

--- a/lib/engine/engine-gpu/src/plugin/atlas.rs
+++ b/lib/engine/engine-gpu/src/plugin/atlas.rs
@@ -4,15 +4,17 @@
 //
 //! © 2025 Obaven Inc. — Apache-2.0 OR MIT
 
-use bevy::prelude::*;
 use super::textures::{MAX_H, MAX_W};
+use bevy::prelude::*;
 
 #[derive(Clone, Copy)]
 struct Rect {
-    off:  UVec2,
+    off: UVec2,
     size: UVec2,
 }
 
+#[derive(Resource)]
+/// Minimal 2‑D guillotine allocator used per atlas layer.
 #[derive(Resource)]
 pub struct AtlasAllocator {
     free: Vec<Rect>,
@@ -21,7 +23,10 @@ pub struct AtlasAllocator {
 impl Default for AtlasAllocator {
     fn default() -> Self {
         Self {
-            free: vec![Rect { off: UVec2::ZERO, size: UVec2::new(MAX_W, MAX_H) }],
+            free: vec![Rect {
+                off: UVec2::ZERO,
+                size: UVec2::new(MAX_W, MAX_H),
+            }],
         }
     }
 }
@@ -38,14 +43,14 @@ impl AtlasAllocator {
         // right strip
         if rect.size.x > size.x {
             self.free.push(Rect {
-                off:  UVec2::new(rect.off.x + size.x, rect.off.y),
+                off: UVec2::new(rect.off.x + size.x, rect.off.y),
                 size: UVec2::new(rect.size.x - size.x, size.y),
             });
         }
         // bottom strip
         if rect.size.y > size.y {
             self.free.push(Rect {
-                off:  UVec2::new(rect.off.x, rect.off.y + size.y),
+                off: UVec2::new(rect.off.x, rect.off.y + size.y),
                 size: UVec2::new(rect.size.x, rect.size.y - size.y),
             });
         }

--- a/lib/engine/engine-gpu/src/plugin/labels.rs
+++ b/lib/engine/engine-gpu/src/plugin/labels.rs
@@ -1,11 +1,14 @@
 use bevy::render::render_graph::RenderLabel;
 
-/// Node labels used inside the Core3d graph.
+/// Node label for the automata compute step.
 #[derive(Debug, Clone, Copy, Hash, PartialEq, Eq, RenderLabel)]
 pub struct AutomataStepLabel;
+/// Node label for the dual-contouring stage.
 #[derive(Debug, Clone, Copy, Hash, PartialEq, Eq, RenderLabel)]
 pub struct DualContourLabel;
+/// Node label for drawing voxel debug geometry.
 #[derive(Debug, Clone, Copy, Hash, PartialEq, Eq, RenderLabel)]
 pub struct DrawVoxelLabel;
+/// Node label for the optional mesh-shader path.
 #[derive(Debug, Clone, Copy, Hash, PartialEq, Eq, RenderLabel)]
 pub struct MeshPathLabel;

--- a/lib/engine/engine-gpu/src/plugin/textures.rs
+++ b/lib/engine/engine-gpu/src/plugin/textures.rs
@@ -7,26 +7,33 @@ use bevy::{
     render::render_resource::{Extent3d, TextureDimension, TextureFormat, TextureUsages},
 };
 
+/// Width of the voxel atlas in texels.
 pub const MAX_W: u32 = 1024;
+/// Height of the voxel atlas in texels.
 pub const MAX_H: u32 = 1024;
+/// Maximum number of atlas layers.
 pub const MAX_LAYERS: u32 = 128;
 
 /* ────────────────────────────────────────────────────────────── */
 /* 3-D sparse voxel atlas (R8Uint, storage-qualified)            */
 /* ────────────────────────────────────────────────────────────── */
+/// Create a 3‑D R8Uint texture suitable for storing automaton state.
 pub fn make_atlas(label: &'static str) -> Image {
     let data = vec![0u8; (MAX_W * MAX_H * MAX_LAYERS) as usize];
 
     let mut img = Image::new_fill(
-        Extent3d { width: MAX_W, height: MAX_H, depth_or_array_layers: MAX_LAYERS },
+        Extent3d {
+            width: MAX_W,
+            height: MAX_H,
+            depth_or_array_layers: MAX_LAYERS,
+        },
         TextureDimension::D3,
         &data,
         TextureFormat::R8Uint,
         RenderAssetUsages::RENDER_WORLD,
     );
     img.texture_descriptor.label = Some(label);
-    img.texture_descriptor.usage |=
-        TextureUsages::STORAGE_BINDING | TextureUsages::TEXTURE_BINDING;
+    img.texture_descriptor.usage |= TextureUsages::STORAGE_BINDING | TextureUsages::TEXTURE_BINDING;
     img
 }
 
@@ -34,18 +41,22 @@ pub fn make_atlas(label: &'static str) -> Image {
 /* 2-D signalling texture (one byte per texel, same footprint    */
 /* as a single atlas layer).                                     */
 /* ────────────────────────────────────────────────────────────── */
+/// Create a 2‑D signalling texture sharing the atlas footprint.
 pub fn make_image(label: &'static str) -> Image {
     let data = vec![0u8; (MAX_W * MAX_H) as usize];
 
     let mut img = Image::new_fill(
-        Extent3d { width: MAX_W, height: MAX_H, depth_or_array_layers: 1 },
+        Extent3d {
+            width: MAX_W,
+            height: MAX_H,
+            depth_or_array_layers: 1,
+        },
         TextureDimension::D2,
         &data,
         TextureFormat::R8Uint,
         RenderAssetUsages::RENDER_WORLD,
     );
     img.texture_descriptor.label = Some(label);
-    img.texture_descriptor.usage |=
-        TextureUsages::STORAGE_BINDING | TextureUsages::TEXTURE_BINDING;
+    img.texture_descriptor.usage |= TextureUsages::STORAGE_BINDING | TextureUsages::TEXTURE_BINDING;
     img
 }

--- a/lib/engine/engine-render/src/command_executor/mod.rs
+++ b/lib/engine/engine-render/src/command_executor/mod.rs
@@ -1,26 +1,29 @@
 //! Spawns automata & maps UI commands > AutomatonInfo.
 
-use std::sync::Arc;
+//! Executes high-level automata commands and related helpers.
+
 use bevy::prelude::*;
 use engine_common::controls::camera::WorldCamera;
 use engine_core::{
     automata::{AutomatonInfo, GpuGridSlice},
-    events::{AutomataCommand, AutomatonAdded, AutomatonId, AutomatonRemoved, GenerateDebugFloor, ToggleDebugGrid},
+    events::{
+        AutomataCommand, AutomatonAdded, AutomatonId, AutomatonRemoved, GenerateDebugFloor,
+        ToggleDebugGrid,
+    },
     prelude::{AppState, AutomataRegistry, RuleRegistry},
 };
 use serde_json::Value;
+use std::sync::Arc;
 
 use crate::render::materials::debug::debug_grid::DebugGridTag;
 /* ───────────────────────────── constants ───────────────────────────── */
 
-const SLICE_SIDE:   u32  = 256;
+const SLICE_SIDE: u32 = 256;
 const DEFAULT_VOXEL: f32 = 4.0;
-const BG:           Color = Color::srgb(0.07, 0.07, 0.07);
+const BG: Color = Color::srgb(0.07, 0.07, 0.07);
 
 /* ───────────────────────────── plugin ─────────────────────────────── */
-
-
-
+/// Routes `AutomataCommand` events to concrete actions.
 pub struct CommandExecutorPlugin;
 impl Plugin for CommandExecutorPlugin {
     fn build(&self, app: &mut App) {
@@ -37,12 +40,9 @@ impl Plugin for CommandExecutorPlugin {
             // NEW: floor & grid handlers (same set so they run before Logic/Render)
             .add_systems(
                 Update,
-                (
-                    handle_generate_floor,
-                    handle_toggle_grid,
-                )
-                .in_set(MainSet::Input)
-                .run_if(in_state(AppState::InGame)),
+                (handle_generate_floor, handle_toggle_grid)
+                    .in_set(MainSet::Input)
+                    .run_if(in_state(AppState::InGame)),
             )
             .add_systems(OnEnter(AppState::MainMenu), clear_on_main_menu);
     }
@@ -50,7 +50,7 @@ impl Plugin for CommandExecutorPlugin {
 
 fn clear_on_main_menu(
     mut registry: ResMut<AutomataRegistry>,
-    mut removed:  EventWriter<AutomatonRemoved>,
+    mut removed: EventWriter<AutomatonRemoved>,
 ) {
     for id in registry.list().iter().map(|a| a.id).collect::<Vec<_>>() {
         registry.remove(id);
@@ -60,12 +60,12 @@ fn clear_on_main_menu(
 
 #[allow(clippy::too_many_arguments)]
 fn handle_commands(
-    mut cmd_reader:     EventReader<AutomataCommand>,
-    mut registry:       ResMut<AutomataRegistry>,
-    rules:              Res<RuleRegistry>,
-    mut added_writer:   EventWriter<AutomatonAdded>,
+    mut cmd_reader: EventReader<AutomataCommand>,
+    mut registry: ResMut<AutomataRegistry>,
+    rules: Res<RuleRegistry>,
+    mut added_writer: EventWriter<AutomatonAdded>,
     mut removed_writer: EventWriter<AutomatonRemoved>,
-    mut commands:       Commands,
+    mut commands: Commands,
 ) {
     for event in cmd_reader.read() {
         match *event {
@@ -78,15 +78,15 @@ fn handle_commands(
 
                 /* logical slice – offset always (0,0); layer filled in later */
                 let gpu_slice = GpuGridSlice {
-                    layer: 0,                  // real Z picked by atlas allocator
+                    layer: 0, // real Z picked by atlas allocator
                     offset: UVec2::ZERO,
-                    size:   UVec2::splat(SLICE_SIDE),
-                    rule:   id.clone(),
+                    size: UVec2::splat(SLICE_SIDE),
+                    rule: id.clone(),
                     rule_bits: 0,
                 };
 
                 let info = AutomatonInfo {
-                    id: AutomatonId(0),        // overwritten by registry
+                    id: AutomatonId(0), // overwritten by registry
                     name: id.clone(),
                     rule: Arc::clone(rule),
                     params: Value::Null,
@@ -117,45 +117,55 @@ fn handle_commands(
 }
 
 /* ─────────────────────── camera helper ───────────────────────────── */
+/// Recentre the world camera on the most recently spawned automaton.
 pub fn focus_camera_on_new_auto(
     mut added: EventReader<AutomatonAdded>,
-    registry:  Res<AutomataRegistry>,
+    registry: Res<AutomataRegistry>,
     mut cam_q: Query<&mut Transform, With<WorldCamera>>,
 ) {
-    let Some(ev)   = added.read().last() else { return };
-    let Some(info) = registry.get(ev.id)  else { return };
-    let Ok(mut tf) = cam_q.single_mut()   else { return };
+    let Some(ev) = added.read().last() else {
+        return;
+    };
+    let Some(info) = registry.get(ev.id) else {
+        return;
+    };
+    let Ok(mut tf) = cam_q.single_mut() else {
+        return;
+    };
 
     let grid_sz = info.slice.size.as_vec2();
-    let centre  = info.world_offset + grid_sz.extend(0.0) * 0.5 * info.voxel_size;
+    let centre = info.world_offset + grid_sz.extend(0.0) * 0.5 * info.voxel_size;
 
     tf.translation.x = centre.x;
     tf.translation.y = centre.y;
 }
 
-
 fn handle_generate_floor(
-    mut ev:  EventReader<GenerateDebugFloor>,
+    mut ev: EventReader<GenerateDebugFloor>,
     mut out: EventWriter<AutomataCommand>,
 ) {
     if !ev.is_empty() {
-        out.write(AutomataCommand::SeedPattern { id: "__debug_floor__".into() });
+        out.write(AutomataCommand::SeedPattern {
+            id: "__debug_floor__".into(),
+        });
         ev.clear();
     }
 }
 
-
 fn handle_toggle_grid(
     mut ev: EventReader<ToggleDebugGrid>,
-    mut q:  Query<&mut Visibility, With<DebugGridTag>>,
+    mut q: Query<&mut Visibility, With<DebugGridTag>>,
 ) {
-    if ev.is_empty() { return; }
-    if let Ok(mut vis) = q.single_mut() {          // <- unwrap the Result
+    if ev.is_empty() {
+        return;
+    }
+    if let Ok(mut vis) = q.single_mut() {
+        // <- unwrap the Result
         *vis = match *vis {
-            Visibility::Hidden    => Visibility::Visible,
-            Visibility::Visible   => Visibility::Hidden,
+            Visibility::Hidden => Visibility::Visible,
+            Visibility::Visible => Visibility::Hidden,
             Visibility::Inherited => Visibility::Hidden,
         };
     }
     ev.clear();
- }
+}

--- a/lib/engine/engine-render/src/lib.rs
+++ b/lib/engine/engine-render/src/lib.rs
@@ -1,14 +1,18 @@
 //! top-level of **engine-render** – nothing here should leak internals.
 
+#![warn(missing_docs)]
+
 pub mod render;
 
 use bevy_ecs::resource::Resource;
 
 /* helper wrapper ---------------------------------------------------- */
+
 #[derive(Resource, Clone)]
+/// Wrapper around rule parameters passed to rendering materials.
 pub struct RuleParams(pub serde_json::Value);
 
 /* convenience re-exports ------------------------------------------- */
-pub mod prelude;
 pub mod command_executor;
 pub mod plugin;
+pub mod prelude;

--- a/lib/engine/engine-render/src/plugin.rs
+++ b/lib/engine/engine-render/src/plugin.rs
@@ -1,14 +1,18 @@
 //! engine/plugin.rs – root **engine** plug-in.
 
+use crate::render::{
+    interpolator::{RenderInterpolator, update_alpha},
+    materials::plugin::MaterialsPlugin,
+};
 use bevy::prelude::*;
 use engine_core::{events::AutomataCommand, prelude::MainSet};
-use crate::render::{interpolator::{update_alpha, RenderInterpolator}, materials::plugin::MaterialsPlugin};
 
-#[cfg(feature = "gpu-compute")]
-use engine_gpu::GpuAutomataComputePlugin;
 #[cfg(feature = "gpu-compute")]
 use engine_core::systems::state::resources::RuntimeFlags;
+#[cfg(feature = "gpu-compute")]
+use engine_gpu::GpuAutomataComputePlugin;
 
+/// Top‑level plugin wiring all renderer systems.
 pub struct EngineRendererPlugin;
 
 impl Plugin for EngineRendererPlugin {
@@ -16,14 +20,11 @@ impl Plugin for EngineRendererPlugin {
         /* 1 ░ global events */
         app.add_event::<AutomataCommand>();
 
-        app.init_resource::<RenderInterpolator>()
-        .add_systems(
+        app.init_resource::<RenderInterpolator>().add_systems(
             Update,
-            update_alpha
-                .in_set(MainSet::Render)
-                .after(MainSet::Logic),          // ← instead of .after(FixedUpdate)
+            update_alpha.in_set(MainSet::Render).after(MainSet::Logic), // ← instead of .after(FixedUpdate)
         );
-        
+
         /* 3 ░ optional GPU compute */
         #[cfg(feature = "gpu-compute")]
         {

--- a/lib/engine/engine-render/src/render/interpolator/mod.rs
+++ b/lib/engine/engine-render/src/render/interpolator/mod.rs
@@ -1,9 +1,14 @@
+//! Frame-to-frame interpolation helpers.
+
 use bevy::prelude::*;
 use engine_core::systems::simulation::{FixedStepConfig, SimAccumulator};
 
 /// `alpha` ∈ [0, 1) — how far the *render* frame is into the next tick.
 #[derive(Resource, Default, Debug, Clone, Copy)]
-pub struct RenderInterpolator { pub alpha: f32 }
+pub struct RenderInterpolator {
+    /// Fractional progress towards the next simulation step.
+    pub alpha: f32,
+}
 
 /// Calculate `alpha` once per frame **after** FixedUpdate systems ran.
 pub fn update_alpha(
@@ -12,5 +17,5 @@ pub fn update_alpha(
     mut ri: ResMut<RenderInterpolator>,
 ) {
     let dt = cfg.dt.as_secs_f64();
-    ri.alpha = (acc.accum / dt) as f32;          // safe: accum < dt by design
+    ri.alpha = (acc.accum / dt) as f32; // safe: accum < dt by design
 }

--- a/lib/engine/engine-render/src/render/materials/debug/debug_floor.rs
+++ b/lib/engine/engine-render/src/render/materials/debug/debug_floor.rs
@@ -1,22 +1,29 @@
-use bevy::{
-    prelude::*, 
-    render::{mesh:: MeshVertexBufferLayoutRef, render_resource::*}, 
-    sprite::{AlphaMode2d, Material2d, Material2dKey}
-};
 use bevy::reflect::TypePath;
+use bevy::{
+    prelude::*,
+    render::{mesh::MeshVertexBufferLayoutRef, render_resource::*},
+    sprite::{AlphaMode2d, Material2d, Material2dKey},
+};
 
+/// Material drawing a zoom-stable reference floor grid.
 #[derive(Asset, TypePath, AsBindGroup, Debug, Clone)]
 pub struct DebugFloorMaterial {
+    /// Shader parameters for the debug floor.
     #[uniform(0)]
     pub params: DebugFloorParams,
 }
 
+/// Uniform block driving [`DebugFloorMaterial`].
 #[repr(C)]
 #[derive(Debug, Copy, Clone, ShaderType, Default)]
 pub struct DebugFloorParams {
-    pub zoom:   f32,
-    pub alpha:  f32,
-    pub _pad:   Vec2,
+    /// World-space zoom factor.
+    pub zoom: f32,
+    /// Alpha transparency of the grid lines.
+    pub alpha: f32,
+    /// Padding to satisfy std140 alignment.
+    pub _pad: Vec2,
+    /// World-space origin of the grid.
     pub origin: Vec2,
 }
 
@@ -34,12 +41,12 @@ impl Material2d for DebugFloorMaterial {
     }
     fn specialize(
         descriptor: &mut RenderPipelineDescriptor,
-        layout:     &MeshVertexBufferLayoutRef,
-        _key:       Material2dKey<Self>,
+        layout: &MeshVertexBufferLayoutRef,
+        _key: Material2dKey<Self>,
     ) -> Result<(), SpecializedMeshPipelineError> {
-        let vertex_layout = layout.0.get_layout(&[
-            Mesh::ATTRIBUTE_POSITION.at_shader_location(0),
-        ])?;
+        let vertex_layout = layout
+            .0
+            .get_layout(&[Mesh::ATTRIBUTE_POSITION.at_shader_location(0)])?;
         descriptor.vertex.buffers = vec![vertex_layout];
         Ok(())
     }

--- a/lib/engine/engine-render/src/render/materials/debug/mod.rs
+++ b/lib/engine/engine-render/src/render/materials/debug/mod.rs
@@ -1,3 +1,5 @@
+//! Debugging materials and related plug-ins.
+
 pub mod debug_floor;
 pub mod debug_grid;
 

--- a/lib/engine/engine-render/src/render/materials/debug/plugin.rs
+++ b/lib/engine/engine-render/src/render/materials/debug/plugin.rs
@@ -2,6 +2,7 @@ use bevy::app::{App, Plugin};
 // use tooling::debugging::floor::plugin::DebugFloorPlugin;
 use crate::render::materials::debug::debug_grid::DebugGridPlugin;
 
+/// Registers debugging material plug-ins.
 pub struct DebugMaterialsPlugin;
 
 impl Plugin for DebugMaterialsPlugin {

--- a/lib/engine/engine-render/src/render/materials/mod.rs
+++ b/lib/engine/engine-render/src/render/materials/mod.rs
@@ -1,3 +1,5 @@
+//! Material assets used by the renderer.
+
+pub mod automata;
 pub mod debug;
 pub mod plugin;
-pub mod automata;

--- a/lib/engine/engine-render/src/render/materials/plugin.rs
+++ b/lib/engine/engine-render/src/render/materials/plugin.rs
@@ -2,6 +2,7 @@ use bevy::app::{App, Plugin};
 
 use crate::render::materials::debug::plugin::DebugMaterialsPlugin;
 
+/// Bundles all material plug-ins used by the renderer.
 pub struct MaterialsPlugin;
 
 impl Plugin for MaterialsPlugin {

--- a/lib/engine/engine-render/src/render/minimap.rs
+++ b/lib/engine/engine-render/src/render/minimap.rs
@@ -4,18 +4,17 @@
 //! `render::worldgrid::minimap` module so downstream UI code can keep the
 //! exact same data-flow with **zero logic changes**.
 
-use std::collections::HashMap;
 use bevy::prelude::*;
-use engine_core::{
-    automata::GpuGridSlice,
-    events::AutomatonId,
-};
+use engine_core::{automata::GpuGridSlice, events::AutomatonId};
+use std::collections::HashMap;
 
 /// Per-automaton data required by the minimap overlay.
 #[derive(Clone)]
 pub struct MinimapEntry {
-    pub slice:   GpuGridSlice,  // where in the atlas this board lives
-    pub texture: Handle<Image>, // 2-D view (filled in render-world)
+    /// Atlas slice describing where the board lives.
+    pub slice: GpuGridSlice,
+    /// 2‑D texture view populated in the render world.
+    pub texture: Handle<Image>,
 }
 
 /// Global mapping: `AutomatonId → minimap thumbnail`.


### PR DESCRIPTION
## Summary
- add crate-level rustdoc and missing-doc warnings to engine core
- document GPU plugin resources and helpers
- flesh out renderer interpolation and supporting modules

## Testing
- `cargo check -p engine-core` *(fails: libudev not found)*


------
https://chatgpt.com/codex/tasks/task_e_689278357ff08333ba45a808c79a9ff9